### PR TITLE
Implement selecting multiple consecutive boxes using shift key

### DIFF
--- a/src/django_crispy_tableselect/static/django_crispy_tableselect/tableselect.js
+++ b/src/django_crispy_tableselect/static/django_crispy_tableselect/tableselect.js
@@ -11,17 +11,6 @@ addEventListener("DOMContentLoaded", () => {
   const deselectAllSelectedTextAttribute = "data-trans-deselect-all";
   const numSelectedTextAttribute = "data-trans-num-selected";
 
-  let shiftPressed = false;
-  let lastChangedCheckbox = null;
-
-  document.addEventListener("keydown", (event) => {
-    shiftPressed = event.shiftKey;
-  });
-
-  document.addEventListener("keyup", (event) => {
-    shiftPressed = event.shiftKey;
-  });
-
   /** Checks if nodes are checked. */
   const allChecked = (nodes) => Array.from(nodes).every((node) => node.checked);
   /** Checks if at least one node is checked. */
@@ -48,6 +37,17 @@ addEventListener("DOMContentLoaded", () => {
     const numSelectedPlaceholder = ariaNarrator.getAttribute(
       numSelectedTextAttribute
     );
+
+    let shiftPressed = false;
+    let lastChangedCheckbox = null;
+
+    document.addEventListener("keydown", (event) => {
+      shiftPressed = event.shiftKey;
+    });
+
+    document.addEventListener("keyup", (event) => {
+      shiftPressed = event.shiftKey;
+    });
 
     // Responsible for updating the checked state and accessible label of the checkbox
     const updateSelectAllCheckboxState = () => {
@@ -107,6 +107,10 @@ addEventListener("DOMContentLoaded", () => {
      * Used to implement the 'shift' select multiple pattern.
      */
     const updateAffectedCheckboxes = (currentCheckbox) => {
+      if (!lastChangedCheckbox) {
+        return;
+      }
+
       const nodes = Array.from(rowCheckboxes);
       const targetIndex = nodes.findIndex((el) => el === currentCheckbox);
       const lastChangedIndex = nodes.findIndex(


### PR DESCRIPTION
This implements a relatively common pattern where holding the shift key will select a range of consecutive items.  I feel like adding this feature will positively impact the user experience of end users.

I've found this pattern described quite concisely on StackExchange ([source](https://ux.stackexchange.com/questions/76714/why-isnt-shiftclick-able-to-select-multiple-consecutive-ranges-of-items))

> When selecting items in a list, we can click to select the first item, then use Shift+Click to select another item, then all consecutive items are selected.



Examples of systems that have implemented this pattern include:
- Google's Gmail web interface
- Apple's Finder program
- Windows' File Explorer program

I've noticed there are subtile differences in behaviour between the example implementations. I've not tried to mimic any particular implementations' behaviour as there is no well documented 'correct' behaviour. Might explore and write a blog post about this topic some day...

Video demo (not visible is that I am holding the shift key while clicking the second box) 

https://github.com/techonomydev/django-crispy-tableselect/assets/13856515/e780fcd3-52cf-42e5-877e-abcd3ba604e8
